### PR TITLE
Trigger & action pipeline fixes

### DIFF
--- a/.github/workflows/rebase-action.yml
+++ b/.github/workflows/rebase-action.yml
@@ -243,7 +243,7 @@ jobs:
                 resources = @{
                   repositories = @{
                     self = @{
-                      refName = "refs/heads/yaml-pipeline"
+                      refName = "refs/heads/main"
                     }
                   }
                 };

--- a/.github/workflows/rebase-action.yml
+++ b/.github/workflows/rebase-action.yml
@@ -70,14 +70,10 @@ jobs:
           $gitHubRepository = $env:GITHUB_REPOSITORY
           $commentAuthor = $env:COMMENT_AUTHOR
           $pullRequestUrl = $env:PULL_REQUEST_URL
-          $backportTargetBranch = $env:TARGET_BRANCH
-          $useFork = $env:USE_FORK
 
           Write-Host "GITHUB_REPOSITORY: ${gitHubRepository}"
           Write-Host "COMMENT_AUTHOR: ${commentAuthor}"
           Write-Host "PULL_REQUEST_URL: ${pullRequestUrl}"
-          Write-Host "TARGET_BRANCH: ${backportTargetBranch}"
-          Write-Host "USE_FORK: ${useFork}"
 
           $gitHubAccountPAT = $env:GITHUB_ACCOUNT_PAT
           if (-not ([string]::IsNullOrEmpty($gitHubAccountPAT))) {
@@ -142,7 +138,7 @@ jobs:
             $headers = @{ Authorization = "token ${githubAccountPat}" }
             $uri = "https://api.github.com/repos/$repoOwner/$repoName/collaborators/${commentAuthor}/permission"
             Write-Host "Checking $repoOwner membership for ${commentAuthor} via $uri"
-            $response = Invoke-WebRequest -Headers $headers -Uri $uri
+            $response = Invoke-WebRequest -Headers $headers -Uri $uri -ContentType 'application/vnd.github+json'
             $content = $response.Content | ConvertFrom-Json
             $accessType = $content.permission
             Write-Host "Found membership: $accessType"

--- a/.github/workflows/rebase-trigger.yml
+++ b/.github/workflows/rebase-trigger.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 jobs:
-  launchRebaseBuild:
+  setupRebase:
     runs-on: ubuntu-latest
     # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
@@ -14,9 +14,27 @@ jobs:
       actions: write
       contents: read
       security-events: write
-      id-token: write           # The rebase-action template being invoked requires this permission
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@gitbot rebase')
+    steps:
+      - name: Show Comment
+        shell: pwsh
+        id: show_comment
+        run: |
+          Write-Host "Comment: ${env:COMMENT}"
+        env:
+          COMMENT: "${{ github.event.comment.body }}"
+
+  launchRebaseBuild:
+    needs: setupRebase
     uses: xamarin/rebase-bot-action/.github/workflows/rebase-action.yml@v2.0
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
+      id-token: write           # The rebase-action template being invoked requires this permission
     with:
       pull_request_url: ${{ github.event.issue.pull_request.url }}
       comment_author: ${{ github.actor }}
@@ -29,3 +47,4 @@ jobs:
       ado_project: ${{ secrets.ADO_PROJECT }}
       rebase_pipeline_id: ${{ secrets.REBASE_PIPELINEID }}
       github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}
+


### PR DESCRIPTION
Related PRs: https://github.com/xamarin/rebase-bot-action/pull/6, https://github.com/xamarin/rebase-bot-action/pull/7, https://github.com/xamarin/rebase-bot-action/pull/9, https://github.com/xamarin/rebase-bot-action/pull/10

Pattern the rebase trigger after the backport bot with a setup and launch job.  This is the only way I found worked to support the conditional without syntax errors

Update the action pipeline to launch builds using the rebase-bot-action `main` branch and not `yaml-pipeline` branch